### PR TITLE
Enhance the forked tomcat shutdown mojo to ensure it waits for tomcat…

### DIFF
--- a/src/main/java/com/googlecode/t7mp/AbstractT7BaseMojo.java
+++ b/src/main/java/com/googlecode/t7mp/AbstractT7BaseMojo.java
@@ -49,6 +49,8 @@ public abstract class AbstractT7BaseMojo extends AbstractMojo {
 
     public static final String CONTEXT_PATH_ROOT = "ROOT";
 
+    public static final int DEFAULT_TOMCAT_SHUTDOWN_TIMEOUT = 10;       // in seconds
+
     /**
      * @parameter expression="${project}"
      * @required
@@ -288,6 +290,12 @@ public abstract class AbstractT7BaseMojo extends AbstractMojo {
      * @parameter default-value="1"
      */
     protected int instanceCount = 1;
+
+    /**
+     * @parameter expression="${t7.tomcatShutdownTimeout}" default-value="10"
+     */
+    protected int tomcatShutdownTimeout = DEFAULT_TOMCAT_SHUTDOWN_TIMEOUT;
+
 
     public boolean isWebProject() {
         return this.packaging.equals("war");
@@ -587,4 +595,11 @@ public abstract class AbstractT7BaseMojo extends AbstractMojo {
         this.instanceCount = instanceCount;
     }
 
+   public int getTomcatShutdownTimeout() {
+      return tomcatShutdownTimeout;
+   }
+
+   public void setTomcatShutdownTimeout(int timeout) {
+      this.tomcatShutdownTimeout = timeout;
+   }
 }

--- a/src/main/java/com/googlecode/t7mp/BaseConfiguration.java
+++ b/src/main/java/com/googlecode/t7mp/BaseConfiguration.java
@@ -27,6 +27,7 @@ public class BaseConfiguration implements T7Configuration {
     public static final int DEFAULT_TOMCAT_HTTP_PORT = 8080;
     public static final int DEFAULT_TOMCAT_SHUTDOWN_PORT = 8005;
     public static final String DEFAULT_CONTEXT_PATH_ROOT = "ROOT";
+    public static final int DEFAULT_TOMCAT_SHUTDOWN_TIMEOUT = 10;    // in seconds
     protected TomcatArtifact tomcatArtifact = new TomcatArtifact();
 
     /**
@@ -200,6 +201,11 @@ public class BaseConfiguration implements T7Configuration {
      * @parameter  default-value="1"
      */
     protected int instanceCount = 1;
+
+    /**
+     * @parameter expression="${t7.tomcatShutdownTimeout}" default-value="10"
+     */
+    protected int tomcatShutdownTimeout = DEFAULT_TOMCAT_SHUTDOWN_TIMEOUT;
 
     /* (non-Javadoc)
      * @see com.googlecode.t7mp.PluginConfiguration#isTomcatSetAwait()
@@ -595,7 +601,16 @@ public class BaseConfiguration implements T7Configuration {
         return instanceCount;
     }
 
-    public void setInstanceCount(final int instanceCount) {
+    public void setTomcatShutdownTimeout(int timeout) {
+       this.tomcatShutdownTimeout = timeout;
+    }
+
+    @Override
+    public int getTomcatShutdownTimeout() {
+       return tomcatShutdownTimeout;
+    }
+
+   public void setInstanceCount(final int instanceCount) {
         this.instanceCount = instanceCount;
     }
 }

--- a/src/main/java/com/googlecode/t7mp/RunForkedMojo.java
+++ b/src/main/java/com/googlecode/t7mp/RunForkedMojo.java
@@ -50,12 +50,12 @@ public class RunForkedMojo extends AbstractT7TomcatMojo {
         printInstancesToStart(configurations);
 
         for (InstanceConfiguration configuration : configurations) {
-            getLog().info("Starting Tomcat ...");
-            try {
+           getLog().info("Starting Tomcat instance " + configuration.getId() + " ...");
+           try {
                 mavenPluginContext.getConfiguration().setTomcatHttpPort(configuration.getHttpPort());
                 mavenPluginContext.getConfiguration().setTomcatShutdownPort(configuration.getShutdownPort());
                 mavenPluginContext.getConfiguration().setCatalinaBase(new File(configuration.getCatalinaBasePath()));
-                ForkedInstance p = new ForkedInstance();
+                ForkedInstance p = new ForkedInstance(configuration.getId());
                 p.configureInstance(mavenPluginContext);
                 Thread t = new Thread(p);
                 t.start();

--- a/src/main/java/com/googlecode/t7mp/T7Configuration.java
+++ b/src/main/java/com/googlecode/t7mp/T7Configuration.java
@@ -104,4 +104,5 @@ public interface T7Configuration {
 
     int getInstanceCount();
 
+   int getTomcatShutdownTimeout();
 }

--- a/src/test/java/com/googlecode/t7mp/configuration/LocalMavenRepositoryArtifactResolver.java
+++ b/src/test/java/com/googlecode/t7mp/configuration/LocalMavenRepositoryArtifactResolver.java
@@ -41,9 +41,12 @@ public class LocalMavenRepositoryArtifactResolver implements PluginArtifactResol
     }
 
     private File createLocalMavenRepository() {
-        File userHomeDirectory = new File(System.getProperty("user.home"));
-        File repositoryDirectory = new File(userHomeDirectory, "/.m2/repository");
-        return createLocalMavenRepository(repositoryDirectory);
+       String mavenRepositoryPath = System.getProperty("maven.repo.home");
+       if(StringUtils.isNotBlank(mavenRepositoryPath)) {
+          return createLocalMavenRepository(new File(mavenRepositoryPath));
+       } else {
+          return createLocalMavenRepository(new File(new File(System.getProperty("user.home")), "/.m2/repository"));
+       }
     }
 
     private File createLocalMavenRepository(File file) {


### PR DESCRIPTION
… to shutdown gracefully. - The start and stop mojos now use a temporary file to indicate if an instance is running. - Add a new configuration property tomcatShutdownTimeout to indicate how many seconds the stop mojo should wait for tomcat to shutdown before timing out.