### PR TITLE
Support URIEncoding in server.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.siggi-ci</groupId>
 		<artifactId>siggi-ci-parent</artifactId>
-		<version>1</version>
+		<version>2-alpha-1</version>
 		<relativePath />
 	</parent>
     <groupId>com.googlecode.t7mp</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -375,6 +375,14 @@
             <artifactId>commons-compress</artifactId>
             <version>1.2</version>
         </dependency>
+        <dependency>
+            <!--  Import dependency management from Spring Boot  -->
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-dependencies</artifactId>
+            <version>1.4.1.RELEASE</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
         <!-- TOMCAT -->
         <dependency>
             <groupId>org.apache.tomcat</groupId>

--- a/src/main/java/com/googlecode/t7mp/AbstractT7BaseMojo.java
+++ b/src/main/java/com/googlecode/t7mp/AbstractT7BaseMojo.java
@@ -49,6 +49,8 @@ public abstract class AbstractT7BaseMojo extends AbstractMojo {
 
     public static final String CONTEXT_PATH_ROOT = "ROOT";
 
+    public static final String DEFAULT_URI_ENCODING = "ISO-8859-1";
+
     /**
      * @parameter expression="${project}"
      * @required
@@ -171,7 +173,7 @@ public abstract class AbstractT7BaseMojo extends AbstractMojo {
      * @parameter expression="${t7.tomcatUriEncoding}" default-value="ISO-8859-1"
      *
      */
-    protected String tomcatUriEncoding = "ISO-8859-1";
+    protected String tomcatUriEncoding = DEFAULT_URI_ENCODING;
 
     /**
      * 

--- a/src/main/java/com/googlecode/t7mp/AbstractT7BaseMojo.java
+++ b/src/main/java/com/googlecode/t7mp/AbstractT7BaseMojo.java
@@ -167,6 +167,13 @@ public abstract class AbstractT7BaseMojo extends AbstractMojo {
     protected String tomcatHostName = "localhost";
 
     /**
+     *
+     * @parameter expression="${t7.tomcatUriEncoding}" default-value="ISO-8859-1"
+     *
+     */
+    protected String tomcatUriEncoding = "ISO-8859-1";
+
+    /**
      * 
      * @parameter default-value="${project.build.directory}/tomcat"
      * @readonly // at the moment
@@ -371,6 +378,14 @@ public abstract class AbstractT7BaseMojo extends AbstractMojo {
 
     public void setTomcatHostName(String tomcatHostName) {
         this.tomcatHostName = tomcatHostName;
+    }
+
+    public String getTomcatUriEncoding() {
+        return tomcatUriEncoding;
+    }
+
+    public void setTomcatUriEncoding(String tomcatUriEncoding) {
+        this.tomcatUriEncoding = tomcatUriEncoding;
     }
 
     public File getUserConfigDir() {

--- a/src/main/java/com/googlecode/t7mp/BaseConfiguration.java
+++ b/src/main/java/com/googlecode/t7mp/BaseConfiguration.java
@@ -75,6 +75,13 @@ public class BaseConfiguration implements T7Configuration {
     protected String tomcatHostName = "localhost";
 
     /**
+     *
+     * @parameter expression="${t7.tomcatUriEncoding}" default-value="ISO-8859-1"
+     *
+     */
+    protected String tomcatUriEncoding = "ISO-8859-1";
+
+    /**
      * @parameter  default-value="${project.build.directory}/tomcat"
      * @readonly   // at the moment
      */
@@ -306,6 +313,14 @@ public class BaseConfiguration implements T7Configuration {
 
     public void setTomcatHostName(final String tomcatHostName) {
         this.tomcatHostName = tomcatHostName;
+    }
+
+    public String getTomcatUriEncoding() {
+        return tomcatUriEncoding;
+    }
+
+    public void setTomcatUriEncoding(String tomcatUriEncoding) {
+        this.tomcatUriEncoding = tomcatUriEncoding;
     }
 
     /* (non-Javadoc)

--- a/src/main/java/com/googlecode/t7mp/BaseConfiguration.java
+++ b/src/main/java/com/googlecode/t7mp/BaseConfiguration.java
@@ -27,6 +27,7 @@ public class BaseConfiguration implements T7Configuration {
     public static final int DEFAULT_TOMCAT_HTTP_PORT = 8080;
     public static final int DEFAULT_TOMCAT_SHUTDOWN_PORT = 8005;
     public static final String DEFAULT_CONTEXT_PATH_ROOT = "ROOT";
+    public static final String DEFAULT_URI_ENCODING = "ISO-8859-1";
     protected TomcatArtifact tomcatArtifact = new TomcatArtifact();
 
     /**
@@ -79,7 +80,7 @@ public class BaseConfiguration implements T7Configuration {
      * @parameter expression="${t7.tomcatUriEncoding}" default-value="ISO-8859-1"
      *
      */
-    protected String tomcatUriEncoding = "ISO-8859-1";
+    protected String tomcatUriEncoding = DEFAULT_URI_ENCODING;
 
     /**
      * @parameter  default-value="${project.build.directory}/tomcat"

--- a/src/main/java/com/googlecode/t7mp/T7Configuration.java
+++ b/src/main/java/com/googlecode/t7mp/T7Configuration.java
@@ -50,6 +50,8 @@ public interface T7Configuration {
 
     String getTomcatHostName();
 
+    String getTomcatUriEncoding();
+
     File getCatalinaBase();
 
     void setCatalinaBase(File catalinaBase);

--- a/src/main/java/com/googlecode/t7mp/steps/BuildCatalinaPropertiesFileStep.java
+++ b/src/main/java/com/googlecode/t7mp/steps/BuildCatalinaPropertiesFileStep.java
@@ -18,6 +18,9 @@ package com.googlecode.t7mp.steps;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.Writer;
+import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.UnsupportedCharsetException;
 
 import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
@@ -46,7 +49,19 @@ public class BuildCatalinaPropertiesFileStep implements Step {
             velocityContext.put("tomcatShutdownPort", configuration.getTomcatShutdownPort() + "");
             velocityContext.put("tomcatShutdownCommand", configuration.getTomcatShutdownCommand());
             velocityContext.put("tomcatHostName", configuration.getTomcatHostName());
-            velocityContext.put("tomcatUriEncoding", configuration.getTomcatUriEncoding());
+
+            // check if URI encoding is valid.  If not, throw a descriptive setup exception
+            try {
+                Charset.forName(configuration.getTomcatUriEncoding());
+                velocityContext.put("tomcatUriEncoding", configuration.getTomcatUriEncoding());
+            } catch (UnsupportedCharsetException uce) {
+                throw new TomcatSetupException("Unsupported URI encoding: " + configuration.getTomcatUriEncoding(), uce);
+            } catch (IllegalCharsetNameException icne) {
+                throw new TomcatSetupException("Illegal URI encoding: " + configuration.getTomcatUriEncoding(), icne);
+            } catch (IllegalArgumentException iae) {
+                throw new TomcatSetupException("Null URI encoding not allowed", iae);
+            }
+
             Writer writer = new FileWriter(new File(configuration.getCatalinaBase(), "/conf/catalina.properties"));
             template.merge(velocityContext, writer);
             writer.flush();

--- a/src/main/java/com/googlecode/t7mp/steps/BuildCatalinaPropertiesFileStep.java
+++ b/src/main/java/com/googlecode/t7mp/steps/BuildCatalinaPropertiesFileStep.java
@@ -46,6 +46,7 @@ public class BuildCatalinaPropertiesFileStep implements Step {
             velocityContext.put("tomcatShutdownPort", configuration.getTomcatShutdownPort() + "");
             velocityContext.put("tomcatShutdownCommand", configuration.getTomcatShutdownCommand());
             velocityContext.put("tomcatHostName", configuration.getTomcatHostName());
+            velocityContext.put("tomcatUriEncoding", configuration.getTomcatUriEncoding());
             Writer writer = new FileWriter(new File(configuration.getCatalinaBase(), "/conf/catalina.properties"));
             template.merge(velocityContext, writer);
             writer.flush();

--- a/src/main/resources/com/googlecode/t7mp/conf/catalina.properties
+++ b/src/main/resources/com/googlecode/t7mp/conf/catalina.properties
@@ -119,3 +119,4 @@ http.port=${tomcatHttpPort}
 shutdown.port=${tomcatShutdownPort}
 shutdown.command=${tomcatShutdownCommand}
 tomcat.hostname=${tomcatHostName}
+tomcat.uriEncoding=${tomcatUriEncoding}

--- a/src/main/resources/com/googlecode/t7mp/conf/server.xml
+++ b/src/main/resources/com/googlecode/t7mp/conf/server.xml
@@ -37,7 +37,8 @@
   <Service name="Catalina">
     <Connector port="${http.port}" protocol="HTTP/1.1" 
                connectionTimeout="20000" 
-               redirectPort="8443" />
+               redirectPort="8443"
+               URIEncoding="${tomcat.uriEncoding}" />
     <Engine name="Catalina" defaultHost="${tomcat.hostname}">
       <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
              resourceName="UserDatabase"/>

--- a/src/test/java/com/googlecode/t7mp/steps/ConfigFilesSequenceTest.java
+++ b/src/test/java/com/googlecode/t7mp/steps/ConfigFilesSequenceTest.java
@@ -66,6 +66,7 @@ public class ConfigFilesSequenceTest {
         Mockito.when(configuration.getCatalinaBase()).thenReturn(catalinaBaseDir);
         //        Mockito.when(mojo.getLog()).thenReturn(log);
         Mockito.when(configuration.getTomcatShutdownCommand()).thenReturn("SHUTDOWN");
+        Mockito.when(configuration.getTomcatUriEncoding()).thenReturn(BaseConfiguration.DEFAULT_URI_ENCODING);
         Context context = new DefaultContext(new ChainedArtifactResolver(),configuration);
         ConfigFilesSequence sequence = new ConfigFilesSequence();
         sequence.execute(context);


### PR DESCRIPTION
Add ability to specify the URIEncoding param on the <Connector> element of server.xml.  This allows setting it to UTF-8 for example.  Will default to ISO-8859-1 if not set, which is what Tomcat does also.

Hopefully you can merge this, as I need this change for a work project I am doing that utilizes this maven plugin.